### PR TITLE
setup.cfg usage for packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,14 @@
 [metadata]
 description-file = README.md
 license = LICENSE
+keywords = 'bitcoin litecoin cryptocurrency decred blockchain development',
+classifiers = [
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3 :: Only',
+    'Topic :: Security :: Cryptography',
+    'Development Status :: 4 - Beta',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
+    'Operating System :: OS Independent',
+    'Topic :: Software Development :: Libraries :: Python Modules',
+    ],

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
-# flake8: noqa
-
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
-    name='riemann-tx',
+    name='riemann_tx',
     version='0.9.0',
     description=('Transaction creation library for Bitcoin-like coins'),
     url='https://github.com/summa-tx/riemann',
@@ -11,17 +9,6 @@ setup(
     author_email='james@summa.one',
     license='LGPLv3.0',
     install_requires=[],
-    packages=['riemann'],
-    package_dir={'riemann': 'riemann'},
-    keywords = 'bitcoin litecoin cryptocurrency decred blockchain development',
-    classifiers = [
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3 :: Only',
-        'Topic :: Security :: Cryptography',
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
-        'Operating System :: OS Independent',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        ],
+    packages=find_packages(),
+    install_package_data=True
 )


### PR DESCRIPTION
#29 fix (see) in setup.py and setup.cfg ; do we want to keep riemann-tx as the name, or the more standard riemann_tx?