### PR TITLE
Enforce compact VarInts in Zcash

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Riemann aims to make it easy to create application-specific transactions. It ser
 
 Riemann is NOT a wallet. It does NOT handle keys or create signatures. Riemann is NOT a protocol or RPC implementation. Riemann does NOT communicate with anything. Ever. Riemann is NOT a Script VM. Riemann does NOT check the validity of your scriptsigs.
 
-Riemann is _almost_ stateless. Before calling functions, you select a network. A list of supported networks is in `riemann/networks/__init__.py`. **No networks have been thoroughly tested.**
+Riemann is _almost_ stateless. Before calling functions, you select a network. A list of supported networks is in `riemann/networks/__init__.py`. Tests are made using on-chain transactions, primarily from Bitcoin.
 
 ### Contributing
 

--- a/riemann/tests/tx/test_tx.py
+++ b/riemann/tests/tx/test_tx.py
@@ -70,6 +70,9 @@ class TestVarInt(unittest.TestCase):
     def setUp(self):
         pass
 
+    def tearDown(self):
+        riemann.select_network('bitcoin_main')
+
     def test_one_byte(self):
         res = tx.VarInt(0xfb)
         self.assertEqual(res, b'\xfb')
@@ -132,6 +135,16 @@ class TestVarInt(unittest.TestCase):
             tx.VarInt.from_bytes(b'\xfe')
         self.assertIn(
             'Malformed VarInt. Got: fe',
+            str(context.exception))
+
+    def test_zcash_compact_enforcement(self):
+        riemann.select_network('zcash_main')
+
+        with self.assertRaises(ValueError) as context:
+            tx.VarInt.from_bytes(b'\xfd\x00')
+
+        self.assertIn(
+            'VarInt must be compact. Got:',
             str(context.exception))
 
 

--- a/riemann/tests/tx/test_tx.py
+++ b/riemann/tests/tx/test_tx.py
@@ -141,7 +141,14 @@ class TestVarInt(unittest.TestCase):
         riemann.select_network('zcash_main')
 
         with self.assertRaises(ValueError) as context:
-            tx.VarInt.from_bytes(b'\xfd\x00')
+            tx.VarInt.from_bytes(b'\xfd\x00\x00')
+
+        self.assertIn(
+            'VarInt must be compact. Got:',
+            str(context.exception))
+
+        with self.assertRaises(ValueError) as context:
+            tx.VarInt.from_bytes(b'\xfe\x00\x00\x00\x00')
 
         self.assertIn(
             'VarInt must be compact. Got:',

--- a/riemann/tests/tx/test_tx.py
+++ b/riemann/tests/tx/test_tx.py
@@ -137,6 +137,12 @@ class TestVarInt(unittest.TestCase):
             'Malformed VarInt. Got: fe',
             str(context.exception))
 
+        with self.assertRaises(ValueError) as context:
+            tx.VarInt.from_bytes(b'\xfe\x00\x00\x00')
+        self.assertIn(
+            'Malformed VarInt. Got: fe',
+            str(context.exception))
+
     def test_zcash_compact_enforcement(self):
         riemann.select_network('zcash_main')
 

--- a/riemann/tx/tx.py
+++ b/riemann/tx/tx.py
@@ -198,7 +198,7 @@ class VarInt(ByteData):
         ret = VarInt(utils.le2i(num))
 
         if ('zcash' in riemann.get_current_network_name()
-                and len(num) != len(byte_string)):
+                and len(ret) != len(byte_string)):
             raise ValueError('VarInt must be compact. Got: {}'
                              .format(byte_string.hex()))
 

--- a/riemann/tx/tx.py
+++ b/riemann/tx/tx.py
@@ -191,7 +191,7 @@ class VarInt(ByteData):
             num = num[1:5]
         elif num[0] == 0xff:
             num = num[1:9]
-        if len(num) == 0:
+        if len(num) not in [1, 2, 4, 8]:
             raise ValueError('Malformed VarInt. Got: {}'
                              .format(byte_string.hex()))
 

--- a/riemann/tx/tx.py
+++ b/riemann/tx/tx.py
@@ -191,6 +191,9 @@ class VarInt(ByteData):
             num = num[1:5]
         elif num[0] == 0xff:
             num = num[1:9]
+        if 'zcash' in riemann.get_current_network_name() and num[-1] == 0:
+            raise ValueError('VarInt must be compact. Got: {}'
+                             .format(byte_string.hex()))
         if len(num) == 0:
             raise ValueError('Malformed VarInt. Got: {}'
                              .format(byte_string.hex()))

--- a/riemann/tx/tx.py
+++ b/riemann/tx/tx.py
@@ -183,6 +183,11 @@ class VarInt(ByteData):
         accepts arbitrary length input, gets a VarInt off the front
         '''
         num = byte_string
+        if ('zcash' in riemann.get_current_network_name()
+                and num[-1] == 0
+                and len(num) > 1):
+            raise ValueError('VarInt must be compact. Got: {}'
+                             .format(byte_string.hex()))
         if num[0] <= 0xfc:
             num = num[0:1]
         elif num[0] == 0xfd:
@@ -191,9 +196,6 @@ class VarInt(ByteData):
             num = num[1:5]
         elif num[0] == 0xff:
             num = num[1:9]
-        if 'zcash' in riemann.get_current_network_name() and num[-1] == 0:
-            raise ValueError('VarInt must be compact. Got: {}'
-                             .format(byte_string.hex()))
         if len(num) == 0:
             raise ValueError('Malformed VarInt. Got: {}'
                              .format(byte_string.hex()))

--- a/riemann/tx/tx.py
+++ b/riemann/tx/tx.py
@@ -183,11 +183,6 @@ class VarInt(ByteData):
         accepts arbitrary length input, gets a VarInt off the front
         '''
         num = byte_string
-        if ('zcash' in riemann.get_current_network_name()
-                and num[-1] == 0
-                and len(num) > 1):
-            raise ValueError('VarInt must be compact. Got: {}'
-                             .format(byte_string.hex()))
         if num[0] <= 0xfc:
             num = num[0:1]
         elif num[0] == 0xfd:
@@ -200,7 +195,14 @@ class VarInt(ByteData):
             raise ValueError('Malformed VarInt. Got: {}'
                              .format(byte_string.hex()))
 
-        return VarInt(utils.le2i(num))
+        ret = VarInt(utils.le2i(num))
+
+        if ('zcash' in riemann.get_current_network_name()
+                and len(num) != len(byte_string)):
+            raise ValueError('VarInt must be compact. Got: {}'
+                             .format(byte_string.hex()))
+
+        return ret
 
 
 class Outpoint(ByteData):


### PR DESCRIPTION
Was rereading the spec. Zcash does not allow VarInts to be expressed using more bytes than necessary. e.g. expressing 0xffff as 0xfeffff0000.

This is a good thing that I wish all chains would do.