### PR TITLE
Unsigned decred input

### DIFF
--- a/riemann/tests/helpers.py
+++ b/riemann/tests/helpers.py
@@ -678,8 +678,9 @@ DCR = {
                 {
                     'id': 0,
                     'sequence': 0xFFFFFFFF,
-                    'hash': '0ce98a1ee5669ad51e0e121c4ef898df84d4a4988a184a8b9c4a4141582fd7fd',
+                    'hash': 'fdd72f5841414a9c8b4a188a98a4d484df98f84e1c120e1ed59a66e51e8ae90c',
                     'index': 0,
+                    'tree': 0,
                     'outpoint': '0ce98a1ee5669ad51e0e121c4ef898df84d4a4988a184a8b9c4a4141582fd7fd0000000000'
                     }
                 ]

--- a/riemann/tests/test_simple.py
+++ b/riemann/tests/test_simple.py
@@ -96,6 +96,19 @@ class TestSimple(unittest.TestCase):
                 sequence=0x1234abcd),
             outpoint.to_bytes() + b'\x00' + b'\xcd\xab\x34\x12')
 
+        riemann.select_network('decred_main')
+
+        outpoint = simple.outpoint(
+            tx_id=helpers.DCR['human']['ins'][0]['hash'],
+            index=helpers.DCR['human']['ins'][0]['index'],
+            tree=helpers.DCR['human']['ins'][0]['tree'])
+
+        self.assertEqual(
+            simple.unsigned_input(
+                outpoint=outpoint,
+                sequence=helpers.DCR['human']['ins'][0]['sequence']),
+            helpers.DCR['ser']['tx']['in_unsigned'])
+
     def test_empty_input(self):
         self.assertEqual(
             simple.empty_input(),

--- a/riemann/tx/tx_builder.py
+++ b/riemann/tx/tx_builder.py
@@ -187,6 +187,10 @@ def make_legacy_input(outpoint, stack_script, redeem_script, sequence):
     '''
     Outpoint, byte-like, byte-like, int -> TxIn
     '''
+    if 'decred' in riemann.get_current_network_name():
+        return tx.DecredTxIn(
+            outpoint=outpoint,
+            sequence=utils.i2le_padded(sequence, 4))
     return tx.TxIn(outpoint=outpoint,
                    stack_script=stack_script,
                    redeem_script=redeem_script,


### PR DESCRIPTION
`simple.unsigned_input` now properly creates Decred inputs instead of erroring

Addresses #58
Relies on #56 